### PR TITLE
Fix for spawning into enemies

### DIFF
--- a/thefloatingdutchman/character/player/player_manager.py
+++ b/thefloatingdutchman/character/player/player_manager.py
@@ -12,8 +12,7 @@ class PlayerManager(Manager):
         self._player = None
 
     def spawn(self):
-        healthValue = 100 if self._player is None else self._player._data.health
-        player_data = PlayerData(healthValue, 750, Vector2(
+        player_data = PlayerData(100, 750, Vector2(
             WINDOW_WIDTH/2, WINDOW_HEIGHT/2), 10)
         self._player = PlayerSprite(player_data)
 

--- a/thefloatingdutchman/character/player/player_manager.py
+++ b/thefloatingdutchman/character/player/player_manager.py
@@ -12,7 +12,8 @@ class PlayerManager(Manager):
         self._player = None
 
     def spawn(self):
-        player_data = PlayerData(100, 750, Vector2(
+        healthValue = 100 if self._player is None else self._player._data.health
+        player_data = PlayerData(healthValue, 750, Vector2(
             WINDOW_WIDTH/2, WINDOW_HEIGHT/2), 10)
         self._player = PlayerSprite(player_data)
 

--- a/thefloatingdutchman/game_manager.py
+++ b/thefloatingdutchman/game_manager.py
@@ -73,6 +73,7 @@ class GameManager(Manager):
                         self._room_manager.current_room_id,
                         self._room_manager.set_current_room
                     )
+                    self._player_manager.spawn()
                 time.wait(200)
 
     # resets game
@@ -93,6 +94,7 @@ class GameManager(Manager):
             self._level += 1
             self._room_manager.spawn(self._level)
             self._map.spawn(self._room_manager)
+
 
     def draw(self):
         # self._screen.fill(BLACK)

--- a/thefloatingdutchman/game_manager.py
+++ b/thefloatingdutchman/game_manager.py
@@ -73,7 +73,7 @@ class GameManager(Manager):
                         self._room_manager.current_room_id,
                         self._room_manager.set_current_room
                     )
-                    self._player_manager.spawn()
+                    self._player_manager.player._data.pos.update(WINDOW_WIDTH/2, WINDOW_HEIGHT/2)
                 time.wait(200)
 
     # resets game


### PR DESCRIPTION
Line 26 of enemy_manager.py comments `# picking position a fair distance away from player`
However, the player stays in the same position after finishing a level. The enemies spawn in a range outside the center of the map to try and prevent the player from being automatically damaged by a spawned enemy, but since the player doesn't spawn in the center, this doesn't work. By "spawning" the player back again after every level, this fixes the issue.

A few possible fixes 

1. Respawn the player, keeping the health they had before (this is what is in this PR)
2. After every level, forcefully move the player to the center of the screen by changing the player data
3. Change the enemy spawning logic so that the enemies spawn at a distance from the player instead of the center.

This code is only lightly tested.